### PR TITLE
Basic auth

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -22,7 +22,7 @@ func getVar(envVar string) (string, error) {
 	envVar = strings.Replace(envVar, "-", "_", -1)
 	val := os.Getenv(envVar)
 	if val == "" {
-		return "", errors.New(kv.FormatLog("discovery-go", kv.Error, "missing env var", m{
+		return "", errors.New(kv.FormatLog("discovery-go", kv.Error, "missing.env.var", m{
 			"var": envVar,
 		}))
 	}
@@ -46,9 +46,13 @@ func URL(service, name string) (string, error) {
 		return "", err
 	}
 
-	u := url.URL{
-		Scheme: proto,
-		Host:   fmt.Sprintf("%s:%s", host, port),
+	rawURL := fmt.Sprintf("%s://%s:%s", proto, host, port)
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", errors.New(kv.FormatLog("discovery-go", kv.Error, "missing env var", m{
+			"url":   rawURL,
+			"error": fmt.Errorf("Failed to parse URL: %s", err.Error()),
+		}))
 	}
 	return u.String(), nil
 }

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -31,6 +31,10 @@ func TestMain(m *testing.M) {
 		"SERVICE_BREAK_API_PORT": "5000",
 
 		"SERVICE_LONG_APP_NAME_API_HOST": "arbitrary",
+
+		"SERVICE_WITH_AUTH_HTTP_PROTO": "https",
+		"SERVICE_WITH_AUTH_HTTP_HOST":  "user:pass@api.google.com",
+		"SERVICE_WITH_AUTH_HTTP_PORT":  "80",
 	})
 
 	os.Exit(m.Run())
@@ -40,6 +44,17 @@ func TestTCPDiscovery(t *testing.T) {
 	expected := "tcp://redis.com:6379"
 
 	url, err := discovery.URL("redis", "tcp")
+	if err != nil {
+		t.Fatalf("Unexpected error, %s", err)
+	} else if url != expected {
+		t.Fatalf("Unexpected result, expected: %s, received: %s", expected, url)
+	}
+}
+
+func TestURLwithBasicAuth(t *testing.T) {
+	expected := "https://user:pass@api.google.com:80"
+
+	url, err := discovery.URL("with-auth", "http")
 	if err != nil {
 		t.Fatalf("Unexpected error, %s", err)
 	} else if url != expected {


### PR DESCRIPTION
I'm confused as to why Drone lets the test pass and local doesn't:

```
$ go test
--- FAIL: TestURLwithBasicAuth (0.00s)
    discovery_test.go:61: Unexpected result, expected: https://user:pass@api.google.com:80, received: https://user:pass%40api.google.com:80
FAIL
exit status 1
FAIL    github.com/Clever/discovery-go  0.005s
```

This just changes how we parse the URL to handle things like `@` in the host.
