### PR TITLE
add HostPort method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,7 @@ if err != nil {
 }
 
 
-redisHOST, err := discovery.Host("redis", "tcp")
-if err != nil {
-    logger.Fatal("ERROR: " + err.Error())
-}
-redisPORT, err := discovery.Port("redis", "tcp")
+redisHostPort, err := discovery.HostPort("redis", "tcp")
 if err != nil {
     logger.Fatal("ERROR: " + err.Error())
 }

--- a/README.md
+++ b/README.md
@@ -24,8 +24,17 @@ if err != nil {
     log.Fatal("ERROR: " + err.Error())
 }
 
-
 redisHostPort, err := discovery.HostPort("redis", "tcp")
+if err != nil {
+    logger.Fatal("ERROR: " + err.Error())
+}
+
+redisHost, err := discovery.Host("redis", "tcp")
+if err != nil {
+    logger.Fatal("ERROR: " + err.Error())
+}
+
+redisPort, err := discovery.Port("redis", "tcp")
 if err != nil {
     logger.Fatal("ERROR: " + err.Error())
 }

--- a/discovery.go
+++ b/discovery.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -55,6 +56,22 @@ func URL(service, name string) (string, error) {
 		}))
 	}
 	return u.String(), nil
+}
+
+// HostPort finds the specified host:port combo for a service based off of the service's name and
+// which interface you are accessing. Values are found in environment variables fitting the scheme:
+// SERVICE_{SERVICE NAME}_{INTERFACE NAME}_{PROTO,HOST,PORT}.
+func HostPort(service, name string) (string, error) {
+	host, err := Host(service, name)
+	if err != nil {
+		return "", err
+	}
+	port, err := Port(service, name)
+	if err != nil {
+		return "", err
+	}
+
+	return net.JoinHostPort(host, port), nil
 }
 
 // Proto finds the specified protocol for a service based off of the service's name and which


### PR DESCRIPTION
It's very common for us to want a host:port string for a service (e.g. Thrift services). It's very common for lots of Go libraries to take in a separate proto and hostport string (e.g. `net.Dial`). This adds a HostPort method.
